### PR TITLE
SDB-1937 Problem z pobraniem PaywayList - INVALID_LENGTH

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -160,7 +160,7 @@ final class Client
                 'gatewayUrl' => $gatewayUrl,
                 'paywayList' => [
                     'serviceID' => $this->configuration->getServiceId(),
-                    'messageID' => bin2hex(random_bytes(ClientEnum::MESSAGE_ID_LENGTH))
+                    'messageID' => bin2hex(random_bytes(ClientEnum::MESSAGE_ID_BYTES))
                 ]
             ],
             PaywayListDto::class,
@@ -190,7 +190,7 @@ final class Client
                 'gatewayUrl' => $gatewayUrl,
                 'regulationList' => [
                     'serviceID' => $this->configuration->getServiceId(),
-                    'messageID' => bin2hex(random_bytes(ClientEnum::MESSAGE_ID_LENGTH))
+                    'messageID' => bin2hex(random_bytes(ClientEnum::MESSAGE_ID_BYTES))
                 ]
             ],
             RegulationListDto::class,

--- a/src/Common/Enum/ClientEnum.php
+++ b/src/Common/Enum/ClientEnum.php
@@ -32,4 +32,6 @@ abstract class ClientEnum
     public const PATTERN_GENERAL_ERROR = '/error(.*)/si';
 
     public const MESSAGE_ID_LENGTH = 32;
+    // each byte will give us 2 hex characters for messageId
+    public const MESSAGE_ID_BYTES = 16;
 }


### PR DESCRIPTION
Poprawia problem zgłoszony w https://jira.blue.pl/browse/SDB-1937 - MessgeId przy pobieraniu listy kanałów ma 64 zamiast dozwolonych 32 znaków