### PR TITLE
Aktualizacja guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "LGPL-3.0-only",
     "require": {
         "php": ">=7.2",
-        "guzzlehttp/guzzle": "6.3.*|6.5.*",
+        "guzzlehttp/guzzle": "6.3.*|6.5.*|7.3.*",
         "jms/serializer": "^1.14|^2.0|^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "LGPL-3.0-only",
     "require": {
         "php": ">=7.2",
-        "guzzlehttp/guzzle": "6.3.*|6.5.*|7.3.*",
+        "guzzlehttp/guzzle": "6.3.*|6.5.*|7.3.*|7.4.*",
         "jms/serializer": "^1.14|^2.0|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Podbicie guzzle do wersji 7.3 i 7.4, gdyż występował problem podczas integracji nowymi frameworkami.